### PR TITLE
Update README about the legacy plugin application

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.com.github.breadmoirai:github-release:2.2.12"
+    classpath "com.github.breadmoirai:github-release:2.2.12"
   }
 }
 


### PR DESCRIPTION
The plugin can't be resolved using the classpath  `gradle.plugin.com.github.breadmoirai:github-release:2.2.12` with the legacy plugin application. 
Instead, using `com.github.breadmoirai:github-release:2.2.12` works correctly.