### PR TITLE
Update default target from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ githubRelease {
     owner "breadmoirai" // default is the last part of your group. Eg group: "com.github.breadmoirai" => owner: "breadmoirai"
     repo "github-release" // by default this is set to your project name
     tagName "v1.0.0" // by default this is set to "v${project.version}"
-    targetCommitish "master" // by default this is set to "master"
+    targetCommitish "main" // by default this is set to "main"
     releaseName "v1.0.0" // Release title, by default this is the same as the tagName
     body "" // by default this is empty
     draft false // by default this is false

--- a/src/main/groovy/com/github/breadmoirai/githubreleaseplugin/GithubReleaseExtension.groovy
+++ b/src/main/groovy/com/github/breadmoirai/githubreleaseplugin/GithubReleaseExtension.groovy
@@ -51,7 +51,7 @@ import java.util.concurrent.Callable
  *         </tr>
  *         <tr>
  *             <td>targetCommitish</td>
- *             <td>'master'</td>
+ *             <td>'main'</td>
  *         </tr>
  *         <tr>
  *             <td>releaseName</td>
@@ -139,7 +139,7 @@ class GithubReleaseExtension {
             project.name ?: project.rootProject?.name ?: project.rootProject?.rootProject?.name
         }
         tagName { "v${project.version}" }
-        targetCommitish { 'master' }
+        targetCommitish { 'main' }
         releaseName { "v${project.version}" }
         draft { false }
         prerelease { false }


### PR DESCRIPTION
With GitHub updating the default branch to `main`, users will have to manually specify the `targetCommitish`. I'm updating the target to `main`. Users that are still on `master` can keep on specifying if they wish.