### PR TITLE
Remove groovy-all from implementation configuration

### DIFF
--- a/ast/build.gradle
+++ b/ast/build.gradle
@@ -10,6 +10,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:3.0.9'
     implementation gradleApi()
+    testImplementation 'org.codehaus.groovy:groovy-test:3.0.9'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     implementation project(':ast')
 
     implementation gradleApi()
-    implementation 'org.codehaus.groovy:groovy-all:3.0.9'
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
     implementation group: 'org.apache.tika', name: 'tika-core', version: '2.0.0'
     implementation 'org.zeroturnaround:zt-exec:1.12'


### PR DESCRIPTION
Gradle provides Groovy dependencies on plugin runtime classpaths.