### PR TITLE
Exclude kotlin-stdlib dependencies from implementation configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,10 @@ dependencies {
 
     implementation gradleApi()
     implementation 'org.codehaus.groovy:groovy-all:3.0.9'
-    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
+    implementation('com.squareup.okhttp3:okhttp:4.9.3') {
+        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'
+        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-common'
+    }
     implementation group: 'org.apache.tika', name: 'tika-core', version: '2.0.0'
     implementation 'org.zeroturnaround:zt-exec:1.12'
 


### PR DESCRIPTION
These are provided by Gradle on plugin runtime classpaths.

Will stop this warning from appearing:

> w: Some JAR files in the classpath have the Kotlin Runtime library bundled into them. This may cause difficult to debug problems if there's a different version of the Kotlin Runtime library in the classpath. Consider removing these libraries from the classpath