### PR TITLE
Simplify interactions with githubRelease extension properties

### DIFF
--- a/src/main/groovy/com/github/breadmoirai/githubreleaseplugin/ChangeLogSupplier.groovy
+++ b/src/main/groovy/com/github/breadmoirai/githubreleaseplugin/ChangeLogSupplier.groovy
@@ -35,23 +35,23 @@ class ChangeLogSupplier implements Callable<String> {
 
     private final Project project
 
-    private final Provider<CharSequence> owner
-    private final Provider<CharSequence> repo
-    private final Provider<CharSequence> authorization
-    private final Provider<CharSequence> tag
+    private final Provider<String> owner
+    private final Provider<String> repo
+    private final Provider<String> authorization
+    private final Provider<String> tag
     private final Provider<Boolean> dryRun
 
-    final Property<CharSequence> executable
-    final Property<CharSequence> currentCommit
-    final Property<CharSequence> lastCommit
-    final ListProperty<CharSequence> options
+    final Property<String> executable
+    final Property<String> currentCommit
+    final Property<String> lastCommit
+    final ListProperty<String> options
     private final OkHttpClient client = GithubApi.client
 
     ChangeLogSupplier(Project project,
-                      Provider<CharSequence> ownerProvider,
-                      Provider<CharSequence> repoProvider,
-                      Provider<CharSequence> authorizationProvider,
-                      Provider<CharSequence> tagProvider,
+                      Provider<String> ownerProvider,
+                      Provider<String> repoProvider,
+                      Provider<String> authorizationProvider,
+                      Provider<String> tagProvider,
                       Provider<Boolean> dryRunProvider) {
         this.project = project
         def objects = project.objects
@@ -60,10 +60,10 @@ class ChangeLogSupplier implements Callable<String> {
         this.authorization = authorizationProvider
         this.tag = tagProvider
         this.dryRun = dryRunProvider
-        this.executable = objects.property(CharSequence)
-        this.currentCommit = objects.property(CharSequence)
-        this.lastCommit = objects.property(CharSequence)
-        this.options = objects.listProperty(CharSequence)
+        this.executable = objects.property(String)
+        this.currentCommit = objects.property(String)
+        this.lastCommit = objects.property(String)
+        this.options = objects.listProperty(String)
         setExecutable 'git'
         setCurrentCommit "HEAD"
         setLastCommit { this.getLastReleaseCommit() }
@@ -74,21 +74,21 @@ class ChangeLogSupplier implements Callable<String> {
      * Looks for the previous release's targetCommitish
      * @return
      */
-    private CharSequence getLastReleaseCommit() {
+    private String getLastReleaseCommit() {
         log 'Searching for previous release on Github'
-        CharSequence owner = this.owner.getOrNull()
+        String owner = this.owner.getOrNull()
         if (owner == null) {
             throw new PropertyNotSetException("owner")
         }
-        CharSequence repo = this.repo.getOrNull()
+        String repo = this.repo.getOrNull()
         if (repo == null) {
             throw new PropertyNotSetException("repo")
         }
-        CharSequence auth = authorization.getOrNull()
+        String auth = authorization.getOrNull()
         if (auth == null) {
             throw new PropertyNotSetException("auth")
         }
-        CharSequence tag = this.tag.getOrNull()
+        String tag = this.tag.getOrNull()
         if (tag == null) {
             throw new PropertyNotSetException("tag")
         }
@@ -109,13 +109,13 @@ class ChangeLogSupplier implements Callable<String> {
             log "$i : ${releases[i].tag_name}"
         }
         if (releases.isEmpty() || (releases.size() == 1 && index == 0) || index + 1 == releases.size()) {
-            CharSequence exe = this.executable.getOrNull()
+            String exe = this.executable.getOrNull()
             if (exe == null) {
                 throw new PropertyNotSetException("exe")
             }
             log "Previous release not found"
             log "Searching for earliest commit"
-            List<String> cmd = [exe, "rev-list", "--max-parents=0", "--max-count=1", "HEAD"]*.toString()
+            List<String> cmd = [exe, "rev-list", "--max-parents=0", "--max-count=1", "HEAD"]
             log "Running `${cmd.join(' ')}`"
             def result = new ProcessExecutor()
                     .command(cmd)
@@ -145,10 +145,10 @@ class ChangeLogSupplier implements Callable<String> {
     @Memoized
     String call() {
         log 'Creating...'
-        CharSequence current = currentCommit.get()
-        CharSequence last = lastCommit.get()
-        List<String> opts = options.get()*.toString()
-        CharSequence get = executable.getOrNull()
+        String current = currentCommit.get()
+        String last = lastCommit.get()
+        List<String> opts = options.get()
+        String get = executable.getOrNull()
         if (get == null) {
             throw new PropertyNotSetException('get')
         }
@@ -185,7 +185,7 @@ class ChangeLogSupplier implements Callable<String> {
         this.options.set(options.toList())
     }
 
-    public void setOptions(Iterable<? extends CharSequence> options) {
+    public void setOptions(Iterable<String> options) {
         this.options.set options
     }
 
@@ -193,11 +193,11 @@ class ChangeLogSupplier implements Callable<String> {
         this.options.set(options.toList())
     }
 
-    public void options(Iterable<? extends CharSequence> options) {
+    public void options(Iterable<String> options) {
         this.options.set options
     }
 
-    public void addOption(CharSequence option) {
+    public void addOption(String option) {
         this.options.add(option)
     }
 

--- a/src/main/groovy/com/github/breadmoirai/githubreleaseplugin/GithubApi.groovy
+++ b/src/main/groovy/com/github/breadmoirai/githubreleaseplugin/GithubApi.groovy
@@ -32,9 +32,9 @@ class GithubApi {
     private final Map<String, String> defaultHeaders
     private final Tika tika = new Tika()
 
-    GithubApi(CharSequence authorization) {
+    GithubApi(String authorization) {
         this.defaultHeaders = [
-                'Authorization': authorization.toString(),
+                'Authorization': authorization,
                 'User-Agent'   : 'breadmoirai github-release-gradle-plugin',
                 'Accept'       : 'application/vnd.github.v3+json',
                 'Content-Type' : 'application/json'
@@ -72,14 +72,14 @@ class GithubApi {
         return r
     }
 
-    Response findReleaseByTag(CharSequence owner, CharSequence repo, CharSequence tagName) {
+    Response findReleaseByTag(String owner, String repo, String tagName) {
         String releaseUrl = "$endpoint/repos/$owner/$repo/releases/tags/$tagName"
         connect(releaseUrl) {
             get()
         }
     }
 
-    Response findTagByName(CharSequence owner, CharSequence repo, CharSequence tagName) {
+    Response findTagByName(String owner, String repo, String tagName) {
         String tagUrl = "$endpoint/repos/$owner/$repo/git/refs/tags/$tagName"
         connect(tagUrl) {
             get()
@@ -98,7 +98,7 @@ class GithubApi {
         }
     }
 
-    Response postRelease(CharSequence owner, CharSequence repo, Map data) {
+    Response postRelease(String owner, String repo, Map data) {
         String releaseUrl = "$endpoint/repos/$owner/$repo/releases"
         connect(releaseUrl) {
             post RequestBody.create(JsonOutput.toJson(data), MEDIATYPE_JSON)
@@ -111,14 +111,14 @@ class GithubApi {
         }
     }
 
-    Response getReleases(CharSequence owner, CharSequence repo) {
+    Response getReleases(String owner, String repo) {
         String releaseUrl = "$endpoint/repos/$owner/$repo/releases"
         connect(releaseUrl) {
             get()
         }
     }
 
-    Response getCommits(CharSequence owner, CharSequence repo) {
+    Response getCommits(String owner, String repo) {
         String commitsUrl = "$endpoint/repo/$owner/$repo/commits"
         println ':githubRelease RETRIEVING COMMITS ' + commitsUrl
         connect(commitsUrl) {

--- a/src/main/groovy/com/github/breadmoirai/githubreleaseplugin/GithubReleaseExtension.groovy
+++ b/src/main/groovy/com/github/breadmoirai/githubreleaseplugin/GithubReleaseExtension.groovy
@@ -96,20 +96,20 @@ import java.util.concurrent.Callable
 class GithubReleaseExtension {
 
 
-    final Property<CharSequence> owner
-    final Property<CharSequence> repo
-    final Property<CharSequence> authorization
-    final Property<CharSequence> tagName
-    final Property<CharSequence> targetCommitish
-    final Property<CharSequence> releaseName
+    final Property<String> owner
+    final Property<String> repo
+    final Property<String> authorization
+    final Property<String> tagName
+    final Property<String> targetCommitish
+    final Property<String> releaseName
     final Property<Boolean> generateReleaseNotes
-    final Property<CharSequence> body
+    final Property<String> body
     final Property<Boolean> draft
     final Property<Boolean> prerelease
     final Property<Boolean> overwrite
     final Property<Boolean> allowUploadToExisting
     final Property<Boolean> dryRun
-    final Property<CharSequence> apiEndpoint
+    final Property<String> apiEndpoint
 
     final ConfigurableFileCollection releaseAssets
 
@@ -122,25 +122,24 @@ class GithubReleaseExtension {
     GithubReleaseExtension(Project project) {
         this.project = project
         final ObjectFactory objectFactory = project.objects
-        owner = objectFactory.property(CharSequence)
-        repo = objectFactory.property(CharSequence)
-        authorization = objectFactory.property(CharSequence)
-        tagName = objectFactory.property(CharSequence)
-        targetCommitish = objectFactory.property(CharSequence)
-        releaseName = objectFactory.property(CharSequence)
+        owner = objectFactory.property(String)
+        repo = objectFactory.property(String)
+        authorization = objectFactory.property(String)
+        tagName = objectFactory.property(String)
+        targetCommitish = objectFactory.property(String)
+        releaseName = objectFactory.property(String)
         generateReleaseNotes = objectFactory.property(Boolean)
-        body = objectFactory.property(CharSequence)
+        body = objectFactory.property(String)
         draft = objectFactory.property(Boolean)
         prerelease = objectFactory.property(Boolean)
         releaseAssets = project.files()
         overwrite = objectFactory.property(Boolean)
         allowUploadToExisting = objectFactory.property(Boolean)
         dryRun = objectFactory.property(Boolean)
-        apiEndpoint = objectFactory.property(CharSequence)
+        apiEndpoint = objectFactory.property(String)
 
         owner {
-            def group = project.group.toString()
-            return group.substring(group.lastIndexOf('.') + 1)
+            return project.group.substring(project.group.lastIndexOf('.') + 1)
         }
         repo {
             project.name ?: project.rootProject?.name ?: project.rootProject?.rootProject?.name
@@ -181,27 +180,27 @@ class GithubReleaseExtension {
         this.releaseAssets.setFrom(assets)
     }
 
-    void setToken(CharSequence token) {
+    void setToken(String token) {
         this.authorization.set("Token $token")
     }
 
-    void token(CharSequence token) {
+    void token(String token) {
         this.authorization.set("Token $token")
     }
 
-    void setToken(Provider<? extends CharSequence> token) {
+    void setToken(Provider<String> token) {
         this.authorization.set(token.map { "Token $it" })
     }
 
-    void token(Provider<? extends CharSequence> token) {
+    void token(Provider<String> token) {
         this.authorization.set(token.map { "Token $it" })
     }
 
-    void setToken(Callable<? extends CharSequence> token) {
+    void setToken(Callable<String> token) {
         this.authorization.set(project.provider(token).map { "Token $it" })
     }
 
-    void token(Callable<? extends CharSequence> token) {
+    void token(Callable<String> token) {
         this.authorization.set(project.provider(token).map { "Token $it" })
     }
 

--- a/src/main/groovy/com/github/breadmoirai/githubreleaseplugin/GithubReleaseTask.groovy
+++ b/src/main/groovy/com/github/breadmoirai/githubreleaseplugin/GithubReleaseTask.groovy
@@ -33,21 +33,21 @@ import java.nio.charset.StandardCharsets
 class GithubReleaseTask extends DefaultTask {
 
     @Input
-    final Property<CharSequence> owner
+    final Property<String> owner
     @Input
-    final Property<CharSequence> repo
+    final Property<String> repo
     @Input
-    final Property<CharSequence> authorization
+    final Property<String> authorization
     @Input
-    final Property<CharSequence> tagName
+    final Property<String> tagName
     @Input
-    final Property<CharSequence> targetCommitish
+    final Property<String> targetCommitish
     @Input
-    final Property<CharSequence> releaseName
+    final Property<String> releaseName
     @Input
     final Property<Boolean> generateReleaseNotes
     @Input
-    final Property<CharSequence> body
+    final Property<String> body
     @Input
     final Property<Boolean> draft
     @Input
@@ -62,26 +62,26 @@ class GithubReleaseTask extends DefaultTask {
     @Input
     final Property<Boolean> dryRun
     @Input
-    final Property<CharSequence> apiEndpoint
+    final Property<String> apiEndpoint
 
     GithubReleaseTask() {
         this.setGroup('publishing')
         final ObjectFactory objectFactory = project.objects
-        owner = objectFactory.property(CharSequence)
-        repo = objectFactory.property(CharSequence)
-        authorization = objectFactory.property(CharSequence)
-        tagName = objectFactory.property(CharSequence)
-        targetCommitish = objectFactory.property(CharSequence)
-        releaseName = objectFactory.property(CharSequence)
+        owner = objectFactory.property(String)
+        repo = objectFactory.property(String)
+        authorization = objectFactory.property(String)
+        tagName = objectFactory.property(String)
+        targetCommitish = objectFactory.property(String)
+        releaseName = objectFactory.property(String)
         generateReleaseNotes = objectFactory.property(Boolean)
-        body = objectFactory.property(CharSequence)
+        body = objectFactory.property(String)
         draft = objectFactory.property(Boolean)
         prerelease = objectFactory.property(Boolean)
         releaseAssets = project.files()
         overwrite = objectFactory.property(Boolean)
         allowUploadToExisting = objectFactory.property(Boolean)
         dryRun = objectFactory.property(Boolean)
-        apiEndpoint = objectFactory.property(CharSequence)
+        apiEndpoint = objectFactory.property(String)
     }
 
     private void log(String message) {
@@ -102,11 +102,11 @@ class GithubReleaseTask extends DefaultTask {
                 log "This task is a dry run. All API calls that would modify the repo are disabled. API calls that access the repo information are not disabled. Use this to show what actions would be executed."
             }
             GithubApi.endpoint = apiEndpoint.get()
-            final CharSequence authValue = authorization.get()
+            final String authValue = authorization.get()
             final GithubApi api = new GithubApi(authValue)
-            final CharSequence ownerValue = owner.get()
-            final CharSequence repoValue = repo.get()
-            final CharSequence tagValue = tagName.get()
+            final String ownerValue = owner.get()
+            final String repoValue = repo.get()
+            final String tagValue = tagName.get()
             log 'CHECKING FOR PREVIOUS RELEASE'
             def previousRelease = api.findReleaseByTag ownerValue, repoValue, tagValue
             switch (previousRelease.code) {
@@ -155,7 +155,7 @@ class GithubReleaseTask extends DefaultTask {
         }
     }
 
-    private void createRelease(GithubApi api, CharSequence ownerValue, CharSequence repoValue, CharSequence tagValue) {
+    private void createRelease(GithubApi api, String ownerValue, String repoValue, String tagValue) {
 
         def values = [
                 tag_name              : tagValue,


### PR DESCRIPTION
Hi 👋 

This PR would make the change to use Strings over CharSequence for githubRelease extension properties.

Interacting with CharSequence githubRelease extension properties can result in some syntactical overhead. As an example, when using the tagName from the githubRelease extension, passing that value to another API requires converting that value to a String. This applies to both Groovy and Kotlin.

Groovy:
```Groovy
tagName = githubRelease.tagName.map { it.toString() }
```

Kotlin:
```Kotlin
tagName.set(githubRelease.tagName.map { it.toString() })
```

This tends to add some amount of noise to the code as most APIs use Strings for such things. With this PR, the above code snippets would be simplified to the following:

Groovy:
```Groovy
tagName = githubRelease.tagName
```

Kotlin:
```Kotlin
tagName.set(githubRelease.tagName)
```

Gradle build scan: https://scans.gradle.com/s/butpox5cvgpqo